### PR TITLE
Use full IP prefix length for `/sbin/ip addr del` command

### DIFF
--- a/.kitchen.docker.local.yml
+++ b/.kitchen.docker.local.yml
@@ -14,7 +14,7 @@ driver_config:
   socket: <%= ENV['DOCKER_HOST'] %>
   privileged: true
   provision_command:
-    - apt-get -y install ifupdown dbus
+    - apt-get -y install ifupdown dbus pciutils kmod iw wireless-tools
     - echo "SSHD_OPTS='-o UseDNS=no -o UsePAM=no -o PasswordAuthentication=yes -o UsePrivilegeSeparation=no -o PidFile=/tmp/sshd.pid'" > /etc/default/ssh
     - ln -s /lib/systemd/system/systemd-logind.service /etc/systemd/system/multi-user.target.wants/systemd-logind.service
     - mkdir /etc/systemd/system/sockets.target.wants/

--- a/.kitchen.docker.local.yml
+++ b/.kitchen.docker.local.yml
@@ -13,6 +13,14 @@ driver_config:
 #  use_sudo: true
   socket: <%= ENV['DOCKER_HOST'] %>
   privileged: true
+  provision_command:
+    - apt-get -y install ifupdown dbus
+    - echo "SSHD_OPTS='-o UseDNS=no -o UsePAM=no -o PasswordAuthentication=yes -o UsePrivilegeSeparation=no -o PidFile=/tmp/sshd.pid'" > /etc/default/ssh
+    - ln -s /lib/systemd/system/systemd-logind.service /etc/systemd/system/multi-user.target.wants/systemd-logind.service
+    - mkdir /etc/systemd/system/sockets.target.wants/
+    - ln -s /lib/systemd/system/dbus.socket /etc/systemd/system/sockets.target.wants/dbus.socket
+    - systemctl set-default multi-user.target
+  run_command: /sbin/init
   cap_add:
     - ALL
     - SYS_ADMIN

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,4 +34,4 @@ before_script:
 
 script:
   - '[[ "$TEST_TYPE" == "unit" ]] && bundle exec rake travis || true'
-  - '[[ "$TEST_TYPE" == "integration" ]] && travis_retry bundle exec rake integration:docker[$KITCHEN_REGEXP] || true'
+  - '[[ "$TEST_TYPE" == "integration" ]] && travis_retry travis_wait bundle exec rake integration:docker[$KITCHEN_REGEXP] || true'

--- a/attributes/wifi-bridge.rb
+++ b/attributes/wifi-bridge.rb
@@ -1,2 +1,2 @@
-default['lyraphase-pi']['wifi-bridge']['packages'] = ['parprouted', 'dhcp-helper', 'avahi-daemon']
+default['lyraphase-pi']['wifi-bridge']['packages'] = ['wpasupplicant', 'parprouted', 'dhcp-helper', 'avahi-daemon']
 default['lyraphase-pi']['wifi-bridge']['parprouted']['skip_wireless_ip_clone'] = false

--- a/recipes/wifi-bridge.rb
+++ b/recipes/wifi-bridge.rb
@@ -85,6 +85,12 @@ end
   end
 end
 
+service 'wpa_supplicant' do
+  provider Chef::Provider::Service::Systemd
+  action [:enable, :start]
+end
+
+
 ['parprouted.service',
  'parprouted-watchdog.service',
  'wpa-cli-event-handler.service'].each do |systemd_svc|

--- a/templates/default/network/wireless-bridge-ip-clone.erb
+++ b/templates/default/network/wireless-bridge-ip-clone.erb
@@ -31,7 +31,7 @@ if /sbin/ip addr show $PARPROUTED_IFACE1 | grep -qE "169\.254\."; then
   echo "WARN: eth0 took zeroconf IP... Deleting..."
   eth0_zeroconf_ip=$(/sbin/ip addr show $PARPROUTED_IFACE1 | perl -wne 'm|^\s+inet (169\.254\.\d+\.\d+)/| && print $1')
   echo "ZEROCONF IP: ${eth0_zeroconf_ip}"
-  [ -n "$eth0_zeroconf_ip" ] && /sbin/ip addr del "${eth0_zeroconf_ip}" dev $PARPROUTED_IFACE1
+  [ -n "$eth0_zeroconf_ip" ] && /sbin/ip addr del "${eth0_zeroconf_ip}/32" dev $PARPROUTED_IFACE1
 fi
 
 echo "RUNNING /sbin/ifup $PARPROUTED_IFACE1"
@@ -54,7 +54,7 @@ until ! /sbin/ip addr show $PARPROUTED_IFACE1 | grep -qE "169\.254\." || [ $time
   echo "WARN: eth0 took zeroconf IP... Deleting..."
   eth0_zeroconf_ip=$(/sbin/ip addr show $PARPROUTED_IFACE1 | perl -wne 'm|^\s+inet (169\.254\.\d+\.\d+)/| && print $1')
   echo "ZEROCONF IP: ${eth0_zeroconf_ip}"
-  [ -n "$eth0_zeroconf_ip" ] && /sbin/ip addr del "${eth0_zeroconf_ip}" dev $PARPROUTED_IFACE1
+  [ -n "$eth0_zeroconf_ip" ] && /sbin/ip addr del "${eth0_zeroconf_ip}/32" dev $PARPROUTED_IFACE1
   time=$SECONDS
 done
 


### PR DESCRIPTION
This should avoid the deprecation warning message:

    Warning: Executing wildcard deletion to stay compatible with old scripts.
    Explicitly specify the prefix length (169.254.106.46/32) to avoid this warning.
    This special behaviour is likely to disappear in further releases,
    fix your scripts!