### PR TITLE
Fix test kitchen

### DIFF
--- a/.kitchen.docker.local.yml
+++ b/.kitchen.docker.local.yml
@@ -14,7 +14,7 @@ driver_config:
   socket: <%= ENV['DOCKER_HOST'] %>
   privileged: true
   provision_command:
-    - apt-get -y install ifupdown dbus
+    - apt-get -y install ifupdown dbus pciutils kmod iw wireless-tools
     - echo "SSHD_OPTS='-o UseDNS=no -o UsePAM=no -o PasswordAuthentication=yes -o UsePrivilegeSeparation=no -o PidFile=/tmp/sshd.pid'" > /etc/default/ssh
     - ln -s /lib/systemd/system/systemd-logind.service /etc/systemd/system/multi-user.target.wants/systemd-logind.service
     - mkdir /etc/systemd/system/sockets.target.wants/

--- a/.kitchen.docker.local.yml
+++ b/.kitchen.docker.local.yml
@@ -6,6 +6,10 @@
 ## driver name: docker is for portertech/kitchen-docker
 driver:
   name: docker
+  privileged: true
+  run_command: /sbin/init
+  env_variables:
+    container: docker
 ## driver_plugin: docker is for adnichols/kitchen-docker-api
 
 driver_config:

--- a/.kitchen.docker.local.yml
+++ b/.kitchen.docker.local.yml
@@ -6,10 +6,6 @@
 ## driver name: docker is for portertech/kitchen-docker
 driver:
   name: docker
-  privileged: true
-  run_command: /sbin/init
-  env_variables:
-    container: docker
 ## driver_plugin: docker is for adnichols/kitchen-docker-api
 
 driver_config:
@@ -31,6 +27,14 @@ driver_config:
     - NET_ADMIN
     - NET_BIND_SERVICE
     - NET_BROADCAST
+  run_command: /sbin/init
+  volume:
+  - '/sys/fs/cgroup:/sys/fs/cgroup:ro'
+  devices:
+    - /dev/console
+  run_options:
+    tmpfs:
+    - /run
 
 platforms:
 - name: debian-8.1

--- a/.kitchen.docker.local.yml
+++ b/.kitchen.docker.local.yml
@@ -13,6 +13,14 @@ driver_config:
 #  use_sudo: true
   socket: <%= ENV['DOCKER_HOST'] %>
   privileged: true
+  provision_command:
+    - apt-get -y install ifupdown dbus
+    - echo "SSHD_OPTS='-o UseDNS=no -o UsePAM=no -o PasswordAuthentication=yes -o UsePrivilegeSeparation=no -o PidFile=/tmp/sshd.pid'" > /etc/default/ssh
+    - ln -s /lib/systemd/system/systemd-logind.service /etc/systemd/system/multi-user.target.wants/systemd-logind.service
+    - mkdir /etc/systemd/system/sockets.target.wants/
+    - ln -s /lib/systemd/system/dbus.socket /etc/systemd/system/sockets.target.wants/dbus.socket
+    - systemctl set-default multi-user.target
+  run_command: /sbin/init
   cap_add:
     - ALL
     - SYS_ADMIN

--- a/.kitchen.docker.local.yml
+++ b/.kitchen.docker.local.yml
@@ -26,4 +26,5 @@ driver_config:
 
 platforms:
 - name: debian-8.1
+- name: debian-10.2
 - name: ubuntu-16.04

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -19,6 +19,8 @@ platforms:
   - name: ubuntu-16.04
 # Rasbpian jessie ~= debian 8.0
   - name: debian-8.1
+# Rasbpian buster ~= debian 10
+  - name: debian-10.2
 
 suites:
   - name: default

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -7,11 +7,13 @@ driver:
 
 provisioner:
   name: chef_zero
+  chef_license: accept-no-persist
 
 # Uncomment the following verifier to leverage Inspec instead of Busser (the
 # default verifier)
 # verifier:
 #   name: inspec
+#   chef_license: accept-no-persist
 
 platforms:
   - name: ubuntu-16.04

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,4 +36,4 @@ before_script:
 
 script:
   - '[[ "$TEST_TYPE" == "unit" ]] && bundle exec rake travis || true'
-  - '[[ "$TEST_TYPE" == "integration" ]] && travis_retry travis_wait bundle exec rake integration:docker[$KITCHEN_REGEXP] || true'
+  - '[[ "$TEST_TYPE" == "integration" ]] && travis_retry bundle exec rake integration:docker[$KITCHEN_REGEXP] || true'

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,3 +37,6 @@ before_script:
 script:
   - '[[ "$TEST_TYPE" == "unit" ]] && bundle exec rake travis || true'
   - '[[ "$TEST_TYPE" == "integration" ]] && travis_retry bundle exec rake integration:docker[$KITCHEN_REGEXP] || true'
+after_script:
+  - '[[ "$TEST_TYPE" == "integration" ]] && echo "---------------- DOCKER CONTAINER LOGS ----------------"'
+  - '[[ "$TEST_TYPE" == "integration" ]] && for c in $(docker ps -aq) ; do sudo docker exec -ti $c /bin/journalctl --no-pager ; done'

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,4 +34,4 @@ before_script:
 
 script:
   - '[[ "$TEST_TYPE" == "unit" ]] && bundle exec rake travis || true'
-  - '[[ "$TEST_TYPE" == "integration" ]] && travis_retry bundle exec rake integration:docker[$KITCHEN_REGEXP] || true'
+  - '[[ "$TEST_TYPE" == "integration" ]] && travis_retry travis_wait bundle exec rake integration:docker[$KITCHEN_REGEXP] || true'

--- a/Gemfile
+++ b/Gemfile
@@ -22,9 +22,9 @@ group :test do
 
   group :integration do
     gem 'berkshelf', '~> 6.0'
-    gem 'test-kitchen', '~> 1.16'
+    gem 'test-kitchen', '~> 2.3'
     group :docker do
-      gem 'kitchen-docker', '~> 2.6'
+      gem 'kitchen-docker', '~> 2.9'
     end
     # Use Aaron's Docker Ruby API patch to talk to docker running remotely
     # gem 'kitchen-docker', :github => 'adnichols/kitchen-docker', :branch => 'docker-ruby-api'

--- a/attributes/wifi-bridge.rb
+++ b/attributes/wifi-bridge.rb
@@ -1,2 +1,2 @@
-default['lyraphase-pi']['wifi-bridge']['packages'] = ['parprouted', 'dhcp-helper', 'avahi-daemon']
+default['lyraphase-pi']['wifi-bridge']['packages'] = ['wpasupplicant', 'parprouted', 'dhcp-helper', 'avahi-daemon']
 default['lyraphase-pi']['wifi-bridge']['parprouted']['skip_wireless_ip_clone'] = false

--- a/recipes/wifi-bridge.rb
+++ b/recipes/wifi-bridge.rb
@@ -94,7 +94,6 @@ service 'wpa_supplicant' do
   action [:enable, :start]
 end
 
-
 ['parprouted.service',
  'parprouted-watchdog.service',
  'wpa-cli-event-handler.service'].each do |systemd_svc|

--- a/recipes/wifi-bridge.rb
+++ b/recipes/wifi-bridge.rb
@@ -85,6 +85,12 @@ end
   end
 end
 
+service 'wpa_supplicant' do
+  provider Chef::Provider::Service::Systemd
+  action [:enable, :start]
+end
+
+
 ['parprouted.service',
  'parprouted-watchdog.service',
  'wpa-cli-event-handler.service'].each do |systemd_svc|

--- a/spec/unit/recipes/wifi-bridge_spec.rb
+++ b/spec/unit/recipes/wifi-bridge_spec.rb
@@ -24,7 +24,7 @@ require 'spec_helper'
 describe 'lyraphase-pi::wifi-bridge' do
   # See spec/spec_helper.rb for platform, platform_version setting
   context 'When all attributes are default, on Raspbian 8.0' do
-    let(:packages) { ['parprouted', 'dhcp-helper', 'avahi-daemon'] }
+    let(:packages) { ['wpasupplicant', 'parprouted', 'dhcp-helper', 'avahi-daemon'] }
 
     let(:chef_run) do
       ChefSpec::ServerRunner.new do |node|

--- a/templates/default/network/wireless-bridge-ip-clone.erb
+++ b/templates/default/network/wireless-bridge-ip-clone.erb
@@ -31,7 +31,7 @@ if /sbin/ip addr show $PARPROUTED_IFACE1 | grep -qE "169\.254\."; then
   echo "WARN: eth0 took zeroconf IP... Deleting..."
   eth0_zeroconf_ip=$(/sbin/ip addr show $PARPROUTED_IFACE1 | perl -wne 'm|^\s+inet (169\.254\.\d+\.\d+)/| && print $1')
   echo "ZEROCONF IP: ${eth0_zeroconf_ip}"
-  [ -n "$eth0_zeroconf_ip" ] && /sbin/ip addr del "${eth0_zeroconf_ip}" dev $PARPROUTED_IFACE1
+  [ -n "$eth0_zeroconf_ip" ] && /sbin/ip addr del "${eth0_zeroconf_ip}/32" dev $PARPROUTED_IFACE1
 fi
 
 echo "RUNNING /sbin/ifup $PARPROUTED_IFACE1"
@@ -54,7 +54,7 @@ until ! /sbin/ip addr show $PARPROUTED_IFACE1 | grep -qE "169\.254\." || [ $time
   echo "WARN: eth0 took zeroconf IP... Deleting..."
   eth0_zeroconf_ip=$(/sbin/ip addr show $PARPROUTED_IFACE1 | perl -wne 'm|^\s+inet (169\.254\.\d+\.\d+)/| && print $1')
   echo "ZEROCONF IP: ${eth0_zeroconf_ip}"
-  [ -n "$eth0_zeroconf_ip" ] && /sbin/ip addr del "${eth0_zeroconf_ip}" dev $PARPROUTED_IFACE1
+  [ -n "$eth0_zeroconf_ip" ] && /sbin/ip addr del "${eth0_zeroconf_ip}/32" dev $PARPROUTED_IFACE1
   time=$SECONDS
 done
 

--- a/templates/default/network/wireless-bridge-ip-clone.erb
+++ b/templates/default/network/wireless-bridge-ip-clone.erb
@@ -31,7 +31,7 @@ if /sbin/ip addr show $PARPROUTED_IFACE1 | grep -qE "169\.254\."; then
   echo "WARN: eth0 took zeroconf IP... Deleting..."
   eth0_zeroconf_ip=$(/sbin/ip addr show $PARPROUTED_IFACE1 | perl -wne 'm|^\s+inet (169\.254\.\d+\.\d+)/| && print $1')
   echo "ZEROCONF IP: ${eth0_zeroconf_ip}"
-  [ -n "$eth0_zeroconf_ip" ] && /sbin/ip addr del "${eth0_zeroconf_ip}/32" dev $PARPROUTED_IFACE1
+  [ -n "$eth0_zeroconf_ip" ] && /sbin/ip addr del "${eth0_zeroconf_ip}" dev $PARPROUTED_IFACE1
 fi
 
 echo "RUNNING /sbin/ifup $PARPROUTED_IFACE1"
@@ -54,7 +54,7 @@ until ! /sbin/ip addr show $PARPROUTED_IFACE1 | grep -qE "169\.254\." || [ $time
   echo "WARN: eth0 took zeroconf IP... Deleting..."
   eth0_zeroconf_ip=$(/sbin/ip addr show $PARPROUTED_IFACE1 | perl -wne 'm|^\s+inet (169\.254\.\d+\.\d+)/| && print $1')
   echo "ZEROCONF IP: ${eth0_zeroconf_ip}"
-  [ -n "$eth0_zeroconf_ip" ] && /sbin/ip addr del "${eth0_zeroconf_ip}/32" dev $PARPROUTED_IFACE1
+  [ -n "$eth0_zeroconf_ip" ] && /sbin/ip addr del "${eth0_zeroconf_ip}" dev $PARPROUTED_IFACE1
   time=$SECONDS
 done
 

--- a/test/integration/wifi-bridge/serverspec/wifi-bridge_spec.rb
+++ b/test/integration/wifi-bridge/serverspec/wifi-bridge_spec.rb
@@ -8,6 +8,7 @@ describe 'lyraphase-pi::wifi-bridge' do
   # Serverspec examples can be found at
   # http://serverspec.org/resource_types.html
   [
+    'wpasupplicant',
     'parprouted',
     'dhcp-helper',
     'avahi-daemon'


### PR DESCRIPTION
Cookbook maintenance:

- Update `Gemfile` dependencies to modern versions
- Fix `test-kitchen` runs (mostly).  Don't count on it working in a Docker container!
- Merge `develop` branch changes, minus the breakages with `ip addr * x.x.x.x/32` commands